### PR TITLE
Check UUID column is empty

### DIFF
--- a/src/Uuids.php
+++ b/src/Uuids.php
@@ -14,7 +14,9 @@ trait Uuids
     {
         parent::boot();
         static::creating(function ($model) {
-            $model->{config('uuid.default_uuid_column')} = strtoupper(Uuid::uuid4()->toString());
+            if (!$model->{config('uuid.default_uuid_column')}) {
+                $model->{config('uuid.default_uuid_column')} = strtoupper(Uuid::uuid4()->toString());
+            }
         });
         static::saving(function ($model) {
             $original_uuid = $model->getOriginal(config('uuid.default_uuid_column'));


### PR DESCRIPTION
If the UUID column has already been populated when creating the model, the package should not attempt to overwrite it. This takes into consideration JSON API-compatible APIs, which allows for client-generated IDs.

Fixes #6.