### PR TITLE
Update trait boot function

### DIFF
--- a/src/Uuids.php
+++ b/src/Uuids.php
@@ -10,7 +10,7 @@ trait Uuids
     /**
      * Boot function from laravel.
      */
-    protected static function boot()
+    protected static function bootUuids()
     {
         parent::boot();
         static::creating(function ($model) {

--- a/src/Uuids.php
+++ b/src/Uuids.php
@@ -10,9 +10,8 @@ trait Uuids
     /**
      * Boot function from laravel.
      */
-    protected static function boot()
+    protected static function bootUuids()
     {
-        parent::boot();
         static::creating(function ($model) {
             if (!$model->{config('uuid.default_uuid_column')}) {
                 $model->{config('uuid.default_uuid_column')} = strtoupper(Uuid::uuid4()->toString());


### PR DESCRIPTION
Currently the boot function on this trait is overridden if there is a boot function on the model.  In that case the uuid is not created.

This pull request renames the boot function as described here so that this doesn't happen:
https://laravel-news.com/booting-eloquent-model-traits