### PR TITLE
Enable package discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.2.1-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Emadadly\\LaravelUuid\\LaravelUuidServiceProvider"
+            ]
         }
     },
     "config": {


### PR DESCRIPTION
Since Laravel 5.5 you can now define your service provider in composer.json to automatically load it. I've added it in to help those new or just not used to having to add in the provider manually.