### PR TITLE
FIX: Removes column ambiguity and auto disables incrementing

### DIFF
--- a/src/Uuids.php
+++ b/src/Uuids.php
@@ -3,6 +3,7 @@ namespace Emadadly\LaravelUuid;
 
 use Ramsey\Uuid\Uuid;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Model;
 
 trait Uuids
 {
@@ -12,7 +13,10 @@ trait Uuids
      */
     protected static function bootUuids()
     {
-        static::creating(function ($model) {
+        static::creating(function (Model $model) {
+            if (config('uuid.default_uuid_column') === 'id') {
+                $model->incrementing = false;
+            }
             if (!$model->{config('uuid.default_uuid_column')}) {
                 $model->{config('uuid.default_uuid_column')} = Uuid::uuid4()->toString();
             }
@@ -39,7 +43,7 @@ trait Uuids
             throw (new ModelNotFoundException)->setModel(get_class($this));
         }
     
-        $results = $query->where(config('uuid.default_uuid_column'), $uuid);
+        $results = $query->where($this->getTable().'.'.config('uuid.default_uuid_column'), $uuid);
     
         return $first ? $results->firstOrFail() : $results;
     }


### PR DESCRIPTION
Removes column ambiguity when using named scopes, an issue that would occur if you are using joins in your query on a table that also contains the uuid field.

e.g. if tableA and tableB both contain the uuid column, the below will no longer cause an ambiguity error

```php
$query->where(function ($query) {
    $query->join('tableB', 'tableA.columnA', '=', 'tableB.columnB');
})
->uuid($uuid)
->get();
```

Also auto-disables incrementing if the uuid column is set to `id`, which is useful in that developers no longer need to add this property to potentially dozens of Models.